### PR TITLE
feat: force dark mode site-wide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >


### PR DESCRIPTION
Add 'dark' class to html element in root layout to enable dark mode across the entire site using the existing dark mode CSS variables.

Closes #6

Generated with [Claude Code](https://claude.ai/code)